### PR TITLE
Update syntax for rmagick v5

### DIFF
--- a/lib/tasks/retina_image_tag.rake
+++ b/lib/tasks/retina_image_tag.rake
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 
 namespace :retina_image_tag do
   desc 'convert @2x images to normal images'


### PR DESCRIPTION
Resolves #1

- [x] Update to be compatible with rmagick v5

## Testing

1. Open `irb`
1. Note `require 'rmagick'` returns True